### PR TITLE
Custom tab support

### DIFF
--- a/jupyterhub/src/jupyterhub_config.py
+++ b/jupyterhub/src/jupyterhub_config.py
@@ -462,6 +462,8 @@ if os.environ.get('KUBECTL_VERSION'):
 
 if os.environ.get('CRW_URL'):
     c.Spawner.environment['CRW_URL'] = os.environ.get('CRW_URL')
+if os.environ.get('QUAY_URL'):
+    c.Spawner.environment['QUAY_URL'] = os.environ.get('QUAY_URL')
 
 # Common functions for creating projects, injecting resources etc.
 

--- a/jupyterhub/src/jupyterhub_config.py
+++ b/jupyterhub/src/jupyterhub_config.py
@@ -460,10 +460,10 @@ if os.environ.get('ODO_VERSION'):
 if os.environ.get('KUBECTL_VERSION'):
     c.Spawner.environment['KUBECTL_VERSION'] = os.environ.get('KUBECTL_VERSION')
 
-if os.environ.get('CRW_URL'):
-    c.Spawner.environment['CRW_URL'] = os.environ.get('CRW_URL')
-if os.environ.get('QUAY_URL'):
-    c.Spawner.environment['QUAY_URL'] = os.environ.get('QUAY_URL')
+if os.environ.get('CUSTOM_TAB_1'):
+    c.Spawner.environment['CUSTOM_TAB_1'] = os.environ.get('CUSTOM_TAB_1')
+if os.environ.get('CUSTOM_TAB_2'):
+    c.Spawner.environment['CUSTOM_TAB_2'] = os.environ.get('CUSTOM_TAB_2')
 
 # Common functions for creating projects, injecting resources etc.
 

--- a/jupyterhub/src/jupyterhub_config.py
+++ b/jupyterhub/src/jupyterhub_config.py
@@ -464,6 +464,10 @@ if os.environ.get('CUSTOM_TAB_1'):
     c.Spawner.environment['CUSTOM_TAB_1'] = os.environ.get('CUSTOM_TAB_1')
 if os.environ.get('CUSTOM_TAB_2'):
     c.Spawner.environment['CUSTOM_TAB_2'] = os.environ.get('CUSTOM_TAB_2')
+if os.environ.get('CUSTOM_TAB_3'):
+    c.Spawner.environment['CUSTOM_TAB_3'] = os.environ.get('CUSTOM_TAB_3')
+if os.environ.get('CUSTOM_TAB_4'):
+    c.Spawner.environment['CUSTOM_TAB_4'] = os.environ.get('CUSTOM_TAB_4')
 
 # Common functions for creating projects, injecting resources etc.
 

--- a/templates/external-keycloak-production.json
+++ b/templates/external-keycloak-production.json
@@ -183,6 +183,10 @@
         {
             "name": "CRW_URL",
             "value": "https://codeready-user3-cicd.apps.cluster-dso-80a8.dso-80a8.example.opentlc.com"
+        },
+        {
+            "name": "QUAY_URL",
+            "value": ""
         }
     ],
     "objects": [
@@ -665,6 +669,10 @@
                                     {
                                         "name": "CRW_URL",
                                         "value": "${CRW_URL}"
+                                    },
+                                    {
+                                        "name": "QUAY_URL",
+                                        "value": "${QUAY_URL}"
                                     },
                                     {
                                         "name": "API_SERVER",

--- a/templates/external-keycloak-production.json
+++ b/templates/external-keycloak-production.json
@@ -181,8 +181,20 @@
             "value": "codeready-public"
         },
         {
-            "name": "CRW_URL",
-            "value": "https://codeready-user3-cicd.apps.cluster-dso-80a8.dso-80a8.example.opentlc.com"
+            "name": "CUSTOM_TAB_1",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_2",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_3",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_4",
+            "value": ""
         }
     ],
     "objects": [
@@ -663,8 +675,20 @@
                                         "value": "${KEYCLOAK_CLIENT_ID}"
                                     },
                                     {
-                                        "name": "CRW_URL",
-                                        "value": "${CRW_URL}"
+                                        "name": "CUSTOM_TAB_1",
+                                        "value": "${CUSTOM_TAB_1}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_2",
+                                        "value": "${CUSTOM_TAB_2}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_3",
+                                        "value": "${CUSTOM_TAB_3}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_4",
+                                        "value": "${CUSTOM_TAB_4}"
                                     },
                                     {
                                         "name": "API_SERVER",

--- a/templates/external-keycloak-production.json
+++ b/templates/external-keycloak-production.json
@@ -90,7 +90,7 @@
         },
         {
             "name": "SPAWNER_IMAGE",
-            "value": "quay.io/akrohg/workshop-spawner:latest",
+            "value": "quay.io/akrohg/workshop-spawner-custom:latest",
             "required": true
         },
         {

--- a/templates/external-keycloak-production.json
+++ b/templates/external-keycloak-production.json
@@ -183,10 +183,6 @@
         {
             "name": "CRW_URL",
             "value": "https://codeready-user3-cicd.apps.cluster-dso-80a8.dso-80a8.example.opentlc.com"
-        },
-        {
-            "name": "QUAY_URL",
-            "value": ""
         }
     ],
     "objects": [
@@ -669,10 +665,6 @@
                                     {
                                         "name": "CRW_URL",
                                         "value": "${CRW_URL}"
-                                    },
-                                    {
-                                        "name": "QUAY_URL",
-                                        "value": "${QUAY_URL}"
                                     },
                                     {
                                         "name": "API_SERVER",

--- a/templates/hosted-workshop-production.json
+++ b/templates/hosted-workshop-production.json
@@ -88,7 +88,7 @@
         },
         {
             "name": "SPAWNER_IMAGE",
-            "value": "quay.io/openshifthomeroom/workshop-spawner:7.1.0",
+            "value": "quay.io/akrohg/workshop-spawner-custom:latest",
             "required": true
         },
         {

--- a/templates/hosted-workshop-production.json
+++ b/templates/hosted-workshop-production.json
@@ -142,6 +142,22 @@
             "name": "OAUTH_CLIENT_SECRET",
             "generate": "expression",
             "from": "[a-zA-Z0-9]{32}"
+        },
+        {
+            "name": "CUSTOM_TAB_1",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_2",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_3",
+            "value": ""
+        },
+        {
+            "name": "CUSTOM_TAB_4",
+            "value": ""
         }
     ],
     "objects": [
@@ -419,6 +435,22 @@
                                     {
                                         "name": "OAUTH_CLIENT_SECRET",
                                         "value": "${OAUTH_CLIENT_SECRET}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_1",
+                                        "value": "${CUSTOM_TAB_1}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_2",
+                                        "value": "${CUSTOM_TAB_2}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_3",
+                                        "value": "${CUSTOM_TAB_3}"
+                                    },
+                                    {
+                                        "name": "CUSTOM_TAB_4",
+                                        "value": "${CUSTOM_TAB_4}"
                                     }
                                 ],
                                 "volumeMounts": [


### PR DESCRIPTION
Environment variables should be passed to the Deployment Config as follows:
```
CUSTOM_TAB_1=<tab_label>=<url>
e.g. CUSTOM_TAB_1=Kiali=https://kiali.openshift.com
```

We can offer support for up to 4 custom tabs with this change. It's important to note that content is loaded in iframes, so embedded oauth flows are not possible. For each tab, options are:

1. Delegate the OAuth flow to the workshop-dashboard itself (see external-keycloak deployment spec)
2. Use a form of authentication that doesn't require cross-domain redirects
3. Disable authentication